### PR TITLE
Citation format fixes

### DIFF
--- a/data/book.yml
+++ b/data/book.yml
@@ -5,5 +5,8 @@ short_title: Ancient Terracottas from South Italy and Sicily
 author_first_name: Maria Lucia
 author_last_name: Ferruzza
 author_full_name: Maria Lucia Ferruzza
-publisher: "Los Angeles: Getty Publications, 2016"
+publication_year: 2016
+publisher: Getty Publications
+publisher_short: Getty P
+publisher_location: Los Angeles
 permalink: "http://pubs.getty.edu/museumcatalogues/terracottas/"

--- a/source/partials/_cite.html.haml
+++ b/source/partials/_cite.html.haml
@@ -14,34 +14,34 @@
         #{data.book.author_last_name}, #{data.book.author_first_name}.
         “Cat. #{entry[:info][:cat]}: #{entry[:info][:title]}.” In
         <em>#{data.book.title}</em>, by #{data.book.author_full_name}.
-        #{data.book.publisher}.
+        #{data.book.publisher_location}:
+        #{data.book.publisher}, #{data.book.publication_year}.
         <span class='force-wrap'>#{data.book.permalink}#{path}</span>
       %h6 MLA
       %p
         #{data.book.author_last_name}, #{data.book.author_first_name}.
-        “Cat. #{entry[:info][:cat]}: #{entry[:info][:title]}.” In
+        “Cat. #{entry[:info][:cat]}: #{entry[:info][:title]}.”
         <em>#{data.book.title}</em>. By #{data.book.author_full_name}.
-        #{data.book.publisher}.
+        #{data.book.publisher_location}:
+        #{data.book.publisher_short}, #{data.book.publication_year}.
         <span class="cite-current-date">DD Mon. YYYY</span>
-        <br />
-        Permanent URL:
         <<span class='force-wrap'>#{data.book.permalink}#{path}</span>>.
     - elsif current_page.data.author_first_name
       / Page has author
       %h6 Chicago
       %p
         #{current_page.data.author_last_name}, #{current_page.data.author_first_name}.
-        “#{current_page.data.title}” In <em>#{data.book.title}</em>,
-        by #{data.book.author_full_name}. #{data.book.publisher}.
+        “#{current_page.data.title}.” In <em>#{data.book.title}</em>,
+        by #{data.book.author_full_name}. #{data.book.publisher_location}:
+        #{data.book.publisher}, #{data.book.publication_year}.
         <span class='force-wrap'>#{data.book.permalink}#{path}</span>
       %h6 MLA
       %p
         #{current_page.data.author_last_name}, #{current_page.data.author_first_name}.
-        “#{current_page.data.title}” In <em>#{data.book.title}</em>.
-        By #{data.book.author_full_name}. #{data.book.publisher}.
+        “#{current_page.data.title}.” <em>#{data.book.title}</em>.
+        By #{data.book.author_full_name}. #{data.book.publisher_location}:
+        #{data.book.publisher_short}, #{data.book.publication_year}.
         <span class="cite-current-date">DD Mon. YYYY</span>
-        <br />
-        Permanent URL:
         <<span class='force-wrap'>#{data.book.permalink}#{path}</span>>.
     - else
       / All other pages
@@ -49,15 +49,15 @@
       %p
         #{data.book.author_last_name}, #{data.book.author_first_name}.
         “#{current_page.data.title}” In <em>#{data.book.title}</em>,
-        by #{data.book.author_full_name}. #{data.book.publisher}.
+        by #{data.book.author_full_name}. #{data.book.publisher_location}:
+        #{data.book.publisher}, #{data.book.publication_year}.
         <span class='force-wrap'>#{data.book.permalink}#{path}</span>
       %h6 MLA
       %p
         #{data.book.author_last_name}, #{data.book.author_first_name}.
-        “#{current_page.data.title}” In <em>#{data.book.title}</em>.
-        By #{data.book.author_full_name}. #{data.book.publisher}.
+        “#{current_page.data.title}.” <em>#{data.book.title}</em>.
+        By #{data.book.author_full_name}. #{data.book.publisher_location}:
+        #{data.book.publisher_short}, #{data.book.publication_year}.
         <span class="cite-current-date">DD Mon. YYYY</span>
-        <br />
-        Permanent URL:
         <<span class='force-wrap'>#{data.book.permalink}#{path}</span>>.
-      = link_to "More Information", "#{site_url}/about/#citation-information"
+    = link_to "Full Catalogue Citation", "#{site_url}/about/#citation-information"

--- a/source/views/about.md
+++ b/source/views/about.md
@@ -38,15 +38,14 @@ TK
 
 ## Citation Information
 
-##### Chicago:
-
+> ##### Chicago:
 > Ferruzza, Maria Lucia. *Ancient Terracottas from South Italy and Sicily in the J. Paul Getty Museum*. Los Angeles: Getty Publications, 2016. http://pubs.getty.edu/museumcatalogues/terracottas
 
-##### MLA:
-
+> ##### MLA:
 > Ferruzza, Maria Lucia. *Ancient Terracottas from South Italy and Sicily
-  in the J. Paul Getty Museum*. Los Angeles: Getty P, 2016. 24 Sept. 2015 &#60;http://pubs.getty.edu/museumcatalogues/terracottas&#62;. <br />
-  Permanent URL: http://pubs.getty.edu/museumcatalogues/terracottas
+  in the J. Paul Getty Museum*. Los Angeles: Getty P, 2016. <span class="cite-current-date">DD Mon. YYYY</span> &#60;http://pubs.getty.edu/museumcatalogues/terracottas&#62;.
+
+Permanent URL: [http://pubs.getty.edu/museumcatalogues/terracottas/](http://pubs.getty.edu/museumcatalogues/terracottas/)
 
 ---
 

--- a/source/views/guide.md
+++ b/source/views/guide.md
@@ -1,6 +1,6 @@
 ---
 title: Guide to the Collection of South Italian and Sicilian Terracottas
-author_first_name: Claire L.
+author_first_name: Claire L
 author_last_name: Lyons
 cover: 82.AD.93.1.detail_1
 layout: page


### PR DESCRIPTION
Fixed some of the citation formatting. Notably Chicago uses Getty
Publications and MLA uses Getty P, so broke the variables out in finer
grain in the book.yml and the _cite.html.haml files.

Adjusted the indenting on the more info link, so it would show up not
just in the All other pages part of the if statement

Made some related formatting tweaks to the citation info on the about
page, and included the cite-current-date function there as well.
